### PR TITLE
Remove some control characters as they are not allowed in xml 1.0

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -167,6 +167,6 @@ xml_encode <- function(x) {
   x <- gsub("\003", "", x, fixed = TRUE) # Control-C character are not allowed in xml 1.0
   x <- gsub("\007", "", x, fixed = TRUE) # neither is Bell
   x <- gsub("\010", "", x, fixed = TRUE) # neither is Backspace
-  x <- gsub("\033", "", x, fixed = TRUE) # neither is Escape
+  x <- gsub("\027", "", x, fixed = TRUE) # neither is Escape
   x
 }

--- a/R/package.R
+++ b/R/package.R
@@ -164,5 +164,9 @@ xml_encode <- function(x) {
   x <- gsub("&", "&amp;", x, fixed = TRUE)
   x <- gsub("<", "&lt;", x, fixed = TRUE)
   x <- gsub(">", "&gt;", x, fixed = TRUE)
+  x <- gsub("\003", "", x, fixed = TRUE) # Control-C character are not allowed in xml 1.0
+  x <- gsub("\007", "", x, fixed = TRUE) # neither is Bell
+  x <- gsub("\010", "", x, fixed = TRUE) # neither is Backspace
+  x <- gsub("\033", "", x, fixed = TRUE) # neither is Escape
   x
 }

--- a/tests/testthat/test.R
+++ b/tests/testthat/test.R
@@ -91,3 +91,16 @@ test_that("data frame input", {
 
   expect_equal(x1, x2)
 })
+
+
+
+test_that("Control-C character", {
+  src <- "# Control-C \003
+          # Bell  \007
+          # Escape \027
+          "
+  xml <- xml_parse_data(parse(text = src, keep.source = TRUE))
+  x <- xml2::read_xml(xml)
+  expect_is(x, "xml_document")
+})
+


### PR DESCRIPTION
If some control character exists in the source code the result of xml_parse_data is an invalid xml